### PR TITLE
Fix Nuget Packege Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Test
       run: dotnet test -c Release --no-build
     - name: Output version name
-      run: echo "Version will be '${{github.ref_name}}'"
+      run: echo "Version will be '${{github.ref}}'"
     - name: Pack nugets
-      run: dotnet pack -c Release --no-build --output . -p:PackageVersion=${{github.ref_name}}
+      run: dotnet pack -c Release --no-build --output . -p:PackageVersion=${{github.ref}}
     - name: Push to NuGet
       run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols


### PR DESCRIPTION
github.ref_name no longer seems to work for getting the Tag. Changing to github.ref